### PR TITLE
Add more tags from the spec

### DIFF
--- a/matrix-pushgw.go
+++ b/matrix-pushgw.go
@@ -71,6 +71,10 @@ type Notification struct {
 	Event_id            string `json:"event_id"`
 	Id                  string `json:"id"`
 	Room_id             string `json:"room_id"`
+	Room_Name           string `json:"room_name"`
+	Room_Alias          string `json:"room_alias"`
+	User_Is_Target	    bool `json:"user_is_target"`
+	Prio                string `json:"prio"`
 	Sender              string `json:"sender"`
 	Sender_display_name string `json:"sender_display_name"`
 	Type                string `json:"type"`


### PR DESCRIPTION
There are some more tags from the specification. I'm not a Go-expert. If the room_name is undefined, will the Room_Name in the struct undefined too or will this cause an error? In the spec: https://matrix.org/docs/spec/push_gateway/r0.1.0.html all of the parameters (not devices) are optional.