### PR TITLE
Replace room id tag, not event id

### DIFF
--- a/matrix-pushgw.go
+++ b/matrix-pushgw.go
@@ -126,7 +126,7 @@ func handlePush(w http.ResponseWriter, r *http.Request) {
 			ExpireOn: expire.Format(time.RFC3339),
 			Token: d.Pushkey,
 			ClearPending: false,
-			ReplaceTag: n.Notification.Event_id,
+			ReplaceTag: n.Notification.Room_id,
 			Data: message}
 		b, _ := json.Marshal(m)
 		apiRequest, _ := http.NewRequest("POST", gConfig.UbuntuTouchPushServerUrl, bytes.NewBuffer(b))


### PR DESCRIPTION
Replacing the tag based on event ID makes no sense. Every event can only be sent once. The desired behaviour would be to replace the room id so that a notification from a room will be replaced by another notification.
Otherwise if you turn off your phone and chat with someone using a desktop client, you will receive every single message from this person as a push notification with sound and vibration like a heavy metal concert ;-)