### PR TITLE
Enable member events

### DIFF
--- a/matrix-pushgw.go
+++ b/matrix-pushgw.go
@@ -43,6 +43,7 @@ type Content struct {
 	Format         string `json:"format"`
 	Formatted_body string `json:"formatted_body"`
 	Msgtype        string `json:"msgtype"`
+	Membership     string `json:"membership"`
 }
 
 type Counts struct {


### PR DESCRIPTION
Events with the type "m.room.member" are not receiving. I think it is because the *required* field "membership" is missing in the Content struct.

The content object highly depends on the type of the event. Maybe its better to just forward the content object without encoding it?