### PR TITLE
ClearPending when there are no unread rooms

### DIFF
--- a/matrix-pushgw.go
+++ b/matrix-pushgw.go
@@ -128,7 +128,7 @@ func handlePush(w http.ResponseWriter, r *http.Request) {
 			AppId: d.App_id,
 			ExpireOn: expire.Format(time.RFC3339),
 			Token: d.Pushkey,
-			ClearPending: false,
+			ClearPending: n.Notification.Counts.Unread == 0,
 			ReplaceTag: n.Notification.Room_id,
 			Data: message}
 		b, _ := json.Marshal(m)


### PR DESCRIPTION
If unread equals 0 there is nothing to notify anymore so all pending notifications can be cleared.